### PR TITLE
🔧 Remove unsupported zone option from Duration validations

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@flexbase/openapi-generator",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "description": "Open API code generator",
   "author": {
     "name": "Flexbase Technologies",

--- a/templates/server/validation.expression.hbs
+++ b/templates/server/validation.expression.hbs
@@ -17,7 +17,7 @@
             }
         {{else compare format "===" "duration"}}
             if(Number.isNaN(Number({{safeName}}))) {
-                const {{safeName}}dtTest = Duration.fromISO({{safeName}}, {zone: 'utc'});
+                const {{safeName}}dtTest = Duration.fromISO({{safeName}});
                 if(!{{safeName}}dtTest.isValid) {
                     utilities.addOrSet({{errorsName}}, '{{name}}', `is not valid: ${ {{safeName}}dtTest.invalidExplanation }`);
                 }


### PR DESCRIPTION
## Summary

The `duration` format validator uses a `zone` option on `Duration.fromISO()` that[ is not supported by `luxon`](https://moment.github.io/luxon/api-docs/index.html#durationfromiso), causing build errors in generated code. This PR simply removes that specifier, since durations shouldn't be zone-specific anyway!